### PR TITLE
Fix password reset navigation issue

### DIFF
--- a/src/components/routing/PublicRoutes.tsx
+++ b/src/components/routing/PublicRoutes.tsx
@@ -14,11 +14,13 @@ export const PublicRoutes = () => {
   const isFirstTimeUser = localStorage.getItem("isFirstTimeUser") === "true";
   const isEmailVerified = user?.email_confirmed_at != null;
 
-  // Allow access to email confirmation success page regardless of auth state
-  if (window.location.pathname === "/email-confirmation-success") {
+  // Allow access to email confirmation and reset password success pages regardless of auth state
+  const currentPath = window.location.pathname;
+  if (currentPath === "/email-confirmation-success" || currentPath === "/reset-password-success") {
     return (
       <Routes>
         <Route path="/email-confirmation-success" element={<EmailConfirmationSuccess />} />
+        <Route path="/reset-password-success" element={<ResetPasswordSuccess />} />
       </Routes>
     );
   }

--- a/src/hooks/useResetPassword.ts
+++ b/src/hooks/useResetPassword.ts
@@ -57,8 +57,8 @@ export const useResetPassword = () => {
         description: "Password has been reset successfully",
       });
       
-      // Navigate to success page immediately
-      navigate("/reset-password-success");
+      // Navigate to success page with replace to prevent back navigation
+      navigate("/reset-password-success", { replace: true });
       
     } catch (error: any) {
       console.error("Error in password reset:", error);


### PR DESCRIPTION
Ensure that after a successful password reset, the user is redirected to the appropriate success page instead of the home page. [skip gpt_engineer]