### PR TITLE
Fix redirect URL after password reset

### DIFF
--- a/src/hooks/useResetPassword.ts
+++ b/src/hooks/useResetPassword.ts
@@ -52,6 +52,10 @@ export const useResetPassword = () => {
       }
       
       console.log("Password updated successfully");
+      
+      // Sign out the user to ensure clean state
+      await supabase.auth.signOut();
+      
       toast({
         title: "Success",
         description: "Password has been reset successfully",


### PR DESCRIPTION
Update the redirect URL after a password reset to ensure users are directed to the correct page. [skip gpt_engineer]