### PR TITLE
Fix email confirmation redirect

### DIFF
--- a/src/components/routing/AppRoutes.tsx
+++ b/src/components/routing/AppRoutes.tsx
@@ -12,21 +12,24 @@ export const Routes = () => {
 
   useEffect(() => {
     // Listen for auth state changes
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
+    const { data: { subscription } } = supabase.auth.onAuthStateChange(async (event, session) => {
       console.log("Auth state changed:", event);
       
       // Only redirect on sign out
       if (event === 'SIGNED_OUT') {
         navigate('/signin');
+        return;
       }
 
       // Handle email confirmation specifically
-      if (event === 'USER_UPDATED') {
+      if (event === 'USER_UPDATED' && session?.user?.email_confirmed_at) {
         const currentPath = window.location.pathname;
         
-        // Only redirect to email confirmation if not in password reset flow
-        if (session?.user?.email_confirmed_at && !currentPath.includes('reset-password')) {
-          navigate('/email-confirmation-success');
+        // Only redirect if not already on success page
+        if (!currentPath.includes('email-confirmation-success')) {
+          // Sign out the user to prevent automatic redirect to /app
+          await supabase.auth.signOut();
+          navigate('/email-confirmation-success', { replace: true });
         }
       }
     });

--- a/src/components/routing/PublicRoutes.tsx
+++ b/src/components/routing/PublicRoutes.tsx
@@ -21,6 +21,7 @@ export const PublicRoutes = () => {
       <Routes>
         <Route path="/email-confirmation-success" element={<EmailConfirmationSuccess />} />
         <Route path="/reset-password-success" element={<ResetPasswordSuccess />} />
+        <Route path="*" element={<Navigate to="/signin" />} />
       </Routes>
     );
   }

--- a/src/hooks/useSignUp.ts
+++ b/src/hooks/useSignUp.ts
@@ -30,7 +30,7 @@ export const useSignUp = () => {
             last_name: lastName || null,
             phone_number: phoneNumber,
           },
-          emailRedirectTo: `${window.location.origin}/signin`,
+          emailRedirectTo: `${window.location.origin}/email-confirmation-success`,
         },
       });
 


### PR DESCRIPTION
Update the email confirmation flow to ensure that users are redirected to the correct success page after confirming their email, instead of the incorrect URL. [skip gpt_engineer]