### PR TITLE
Fix email confirmation navigation issue

### DIFF
--- a/src/components/routing/AppRoutes.tsx
+++ b/src/components/routing/AppRoutes.tsx
@@ -15,6 +15,13 @@ export const Routes = () => {
     const { data: { subscription } } = supabase.auth.onAuthStateChange(async (event, session) => {
       console.log("Auth state changed:", event);
       
+      const currentPath = window.location.pathname;
+      
+      // Don't redirect if on success pages
+      if (currentPath === '/email-confirmation-success' || currentPath === '/reset-password-success') {
+        return;
+      }
+
       // Only redirect on sign out
       if (event === 'SIGNED_OUT') {
         navigate('/signin');
@@ -23,14 +30,9 @@ export const Routes = () => {
 
       // Handle email confirmation specifically
       if (event === 'USER_UPDATED' && session?.user?.email_confirmed_at) {
-        const currentPath = window.location.pathname;
-        
-        // Only redirect if not already on success page
-        if (!currentPath.includes('email-confirmation-success')) {
-          // Sign out the user to prevent automatic redirect to /app
-          await supabase.auth.signOut();
-          navigate('/email-confirmation-success', { replace: true });
-        }
+        // Sign out the user to prevent automatic redirect to /app
+        await supabase.auth.signOut();
+        navigate('/email-confirmation-success', { replace: true });
       }
     });
 

--- a/src/components/routing/PublicRoutes.tsx
+++ b/src/components/routing/PublicRoutes.tsx
@@ -13,9 +13,9 @@ export const PublicRoutes = () => {
   const { user } = useAuth();
   const isFirstTimeUser = localStorage.getItem("isFirstTimeUser") === "true";
   const isEmailVerified = user?.email_confirmed_at != null;
-
-  // Allow access to email confirmation and reset password success pages regardless of auth state
   const currentPath = window.location.pathname;
+
+  // Allow access to success pages regardless of auth state
   if (currentPath === "/email-confirmation-success" || currentPath === "/reset-password-success") {
     return (
       <Routes>
@@ -26,6 +26,7 @@ export const PublicRoutes = () => {
     );
   }
 
+  // Handle authenticated user routes
   if (user) {
     if (!isEmailVerified) {
       return <Navigate to="/signup" />;
@@ -38,6 +39,7 @@ export const PublicRoutes = () => {
     return <Navigate to="/app" />;
   }
 
+  // Public routes for unauthenticated users
   return (
     <Routes>
       <Route path="/" element={<Navigate to="/signin" />} />


### PR DESCRIPTION
Addressed an issue where users were redirected to the home page immediately after confirming their email, preventing them from accessing the email confirmation success page. This change ensures that users remain on the confirmation success page after completing the email verification process. [skip gpt_engineer]